### PR TITLE
fix: WordPress 6 and Woo 9 compatibility

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Woo Product Add Tab
 
-Wordpress plugin allows to add additional tab on the product page in WooCommerce.
+WordPress plugin allows to add additional tab on the product page in WooCommerce.
 
 # Description
 
-After activating the plugin, you can create new tabs, change their order and add unique content for each product.
-
-Tested with WooCommerce 2.4.6.
+After activating the plugin, you can create new tabs, change their order and add unique content for
+each product.
 
 # Installation
 
@@ -22,11 +21,15 @@ Enter name and priority.
 
 ## What is priority?
 
-Tabs *priority* determine its position in relation to other tabs. Standard tabs on the product page have the following priority: **Description** - 10, **Additional Information** (shown only when you specify the weight or size) - 20, **Reviews** - 30. For example, for place tab on second place set priority - 15.
-
+Tabs *priority* determine its position in relation to other tabs. Standard tabs on the product page
+have the following priority: **Description** - 10, **Additional Information** (shown only when you
+specify the weight or size) - 20, **Reviews** - 30. For example, for place tab on second place set
+priority - 15.
 
 # Changelog
 
-## 0.8
-* Add i18n capability.
+* WordPress 6.7 and Woo 9.5 compatibility.
 
+## 0.8
+
+* Add i18n capability.

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,11 @@
 === Plugin Name ===
 Contributors: shvv
 Tags: woocommerce
-Requires at least: 3.0.1
-Tested up to: 4.3.1
+Requires at least: 6.2
+Tested up to: 6.7.1
+Requires PHP: 7.4
+WC requires at least: 8.0
+WC tested up to: 9.5.2
 Stable tag: 0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -12,8 +15,6 @@ Plugin allows to add additional tabs on the product page in WooCommerce.
 == Description ==
 
 After activating the plugin, you can create new tabs, change their order and add unique content for each product.
-
-Tested with WooCommerce 2.4.6.
 
 == Installation ==
 
@@ -33,6 +34,8 @@ Tabs priority determine its position in relation to other tabs. Standard tabs on
 
 
 == Changelog ==
+
+* WordPress 6.7 and Woo 9.5 compatibility.
 
 = 0.8 =
 * Add i18n capability.

--- a/woocommerce-add-tab.php
+++ b/woocommerce-add-tab.php
@@ -250,7 +250,7 @@ if ( !class_exists( 'Woocommerce_Add_Tab' ) ) {
 		{
 			foreach ($this->tabs as $tab) {
 				?>
-                <li class="custom_tab"><a href="<?php echo '#custom_tab_' . $tab->ID ?>"><span><?php echo $tab->post_title; ?></span></a></li>
+				<li class="custom_tab"><a href="<?php echo '#custom_tab_' . $tab->ID ?>"><span><?php echo $tab->post_title; ?></span></a></li>
 				<?php
 			}
 		}
@@ -269,9 +269,9 @@ if ( !class_exists( 'Woocommerce_Add_Tab' ) ) {
 				<div id="<?php echo 'custom_tab_' . $tab->ID ?>" class="panel woocommerce_options_panel">
 					<div class="options_group custom_tab_options">
 						<table class="form-table">
-                            <tr>
-                                <td><strong><?php echo $tab->post_title; ?></strong></td>
-                            </tr>
+							<tr>
+								<td><strong><?php echo $tab->post_title; ?></strong></td>
+							</tr>
 							<tr>
 								<td>
 									<?php

--- a/woocommerce-add-tab.php
+++ b/woocommerce-add-tab.php
@@ -247,7 +247,7 @@ if ( !class_exists( 'Woocommerce_Add_Tab' ) ) {
 		{
 			foreach ($this->tabs as $tab) {
 				?>
-				<li class="custom_tab"><a href="<?php echo '#custom_tab_' . $tab->ID ?>"><?php echo $tab->post_title; ?></a></li>
+                <li class="custom_tab"><a href="<?php echo '#custom_tab_' . $tab->ID ?>"><span><?php echo $tab->post_title; ?></span></a></li>
 				<?php
 			}
 		}
@@ -264,10 +264,11 @@ if ( !class_exists( 'Woocommerce_Add_Tab' ) ) {
 			foreach ($this->tabs as $tab) {
 				?>
 				<div id="<?php echo 'custom_tab_' . $tab->ID ?>" class="panel woocommerce_options_panel">
-					<h3> <?php echo $tab->post_title;  ?> </h3>
-
 					<div class="options_group custom_tab_options">
 						<table class="form-table">
+                            <tr>
+                                <td><strong><?php echo $tab->post_title; ?></strong></td>
+                            </tr>
 							<tr>
 								<td>
 									<?php

--- a/woocommerce-add-tab.php
+++ b/woocommerce-add-tab.php
@@ -117,7 +117,7 @@ if ( !class_exists( 'Woocommerce_Add_Tab' ) ) {
 							'show_ui' => true,
 							'show_in_menu' => 'edit.php?post_type=product',
 							'show_in_nav_menus' => true,
-							'supports' => 'title',
+							'supports' => array('title'),
 							'capability_type'     => 'product',
 							'register_meta_box_cb' => array($this, 'add_field')
 					)

--- a/woocommerce-add-tab.php
+++ b/woocommerce-add-tab.php
@@ -2,17 +2,20 @@
 /**
  * Plugin Name: Woo Product Add Tab
  * Plugin URI: https://github.com/shvlv/woocommerce-add-tab
- * Description: Plugin allows you to add additional tabs on the product page in WooCommerce
+ * Description: Plugin allows you to add additional tabs on the product page in WooCommerce.
  * Version: 0.8
  * Author: shvv
  * Author URI: http://shvlv.github.io/
  * License: GPLv2 or later
- * Tested up to: 4.3
+ * Requires at least: 6.2
+ * Tested up to: 6.7.1
+ * Requires PHP: 7.4
+ * WC requires at least: 8.0
+ * WC tested up to: 9.5.2
  * Text Domain: woocommerce-add-tab
  * Domain Path: /languages/
- *
- *
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -65,7 +68,7 @@ if ( !class_exists( 'Woocommerce_Add_Tab' ) ) {
 			add_filter( 'woocommerce_product_tabs', array($this,'display_tabs') );
 
 			/**
-			 * Admin Wordpress hook
+			 * Admin WordPress hook
 			 */
 
 			add_action('admin_enqueue_scripts', array($this,'add_script'));

--- a/woocommerce-add-tab.php
+++ b/woocommerce-add-tab.php
@@ -56,7 +56,7 @@ if ( !class_exists( 'Woocommerce_Add_Tab' ) ) {
 			 */
 
 			add_action('woocommerce_product_write_panel_tabs', array($this,'panel_tabs'));
-			add_action('woocommerce_product_write_panels', array($this,'options_tabs'));
+			add_action('woocommerce_product_data_panels', array($this,'options_tabs'));
 			add_action('woocommerce_process_product_meta', array($this,'save_options'), 10, 2);
 
 			/**


### PR DESCRIPTION
WordPress and WooCommerce never break backward compatibility. Although the plugin has not been touched for 10 years, it works as expected!

Apart from formatting and minor typos, the PR includes only two important changes:
* fix `register_post_type` argument (`supports` must be array)
* replace deprecated `woocommerce_product_write_panels` with `woocommerce_product_data_panels`. Note: despite `woocommerce_product_write_panels` being deprecated since version 2.6, it still works in 9.5.2 :smile: 

PR was initially planned as a fix, but I increased the requirements to facilitate further support. So, there is a breaking change.  